### PR TITLE
Fix deprecated `git://` in clone url

### DIFF
--- a/zish/install.sh
+++ b/zish/install.sh
@@ -32,7 +32,7 @@ echo -e "$(NORMAL 2)..done$(RESET)"
 
 # Install necessary plugins
 echo -e "$(NORMAL 6)Installing zsh-autosuggestions$(RESET)"
-git clone git://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions || exit 1
+git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions || exit 1
 echo -e "$(NORMAL 2)..done$(RESET)"
 echo -e "$(NORMAL 6)Installing zsh-history-substring-search$(RESET)"
 git clone https://github.com/zsh-users/zsh-history-substring-search ~/.oh-my-zsh/custom/plugins/zsh-history-substring-search || exit 1


### PR DESCRIPTION
When using the script, a similar output can be observed.
```
..done
Installing zsh-autosuggestions
Cloning into '/config/.oh-my-zsh/custom/plugins/zsh-autosuggestions'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
The use of `git://` is deprecated and was replaced by `https://`.